### PR TITLE
remove remnants from unused function wrapping, fixes #9

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -13,8 +13,6 @@
         ESP = isNode ? require('esprima') : esprima,
         ESPGEN = isNode ? require('escodegen') : escodegen,  //TODO - package as dependency
         crypto = isNode ? require('crypto') : null,
-        LEADER_WRAP = '(function () { ',
-        TRAILER_WRAP = '\n}());',
         COMMENT_RE = /^\s*istanbul\s+ignore\s+(if|else|next)(?=\W|$)/,
         astgen,
         preconditions,
@@ -356,16 +354,6 @@
      *      file as an array in the file coverage object for that file. Defaults to `false`
      * @param {Boolean} [options.preserveComments] whether comments should be preserved in the output. Defaults to `false`
      * @param {Boolean} [options.noCompact] emit readable code when set. Defaults to `false`
-     * @param {Boolean} [options.noAutoWrap] do not automatically wrap the source in
-     *      an anonymous function before covering it. By default, code is wrapped in
-     *      an anonymous function before it is parsed. This is done because
-     *      some nodejs libraries have `return` statements outside of
-     *      a function which is technically invalid Javascript and causes the parser to fail.
-     *      This construct, however, works correctly in node since module loading
-     *      is done in the context of an anonymous function.
-     *
-     * Note that the semantics of the code *returned* by the instrumenter does not change in any way.
-     * The function wrapper is "unwrapped" before the instrumented code is generated.
      * @param {Object} [options.codeGenerationOptions] an object that is directly passed to the `escodegen`
      *      library as configuration for code generation. The `noCompact` setting is not honored when this
      *      option is specified
@@ -380,7 +368,6 @@
             walkDebug: false,
             coverageVariable: '__coverage__',
             codeGenerationOptions: undefined,
-            noAutoWrap: false,
             noCompact: false,
             embedSource: false,
             preserveComments: false
@@ -614,42 +601,6 @@
         lastSourceMap: function () {
             return this.sourceMap;
         },
-        fixColumnPositions: function (coverState) {
-            var offset = LEADER_WRAP.length,
-                fixer = function (loc) {
-                    if (loc.start.line === 1) {
-                        loc.start.column -= offset;
-                    }
-                    if (loc.end.line === 1) {
-                        loc.end.column -= offset;
-                    }
-                },
-                k,
-                obj,
-                i,
-                locations;
-
-            obj = coverState.statementMap;
-            for (k in obj) {
-                /* istanbul ignore else: has own property */
-                if (obj.hasOwnProperty(k)) { fixer(obj[k]); }
-            }
-            obj = coverState.fnMap;
-            for (k in obj) {
-                /* istanbul ignore else: has own property */
-                if (obj.hasOwnProperty(k)) { fixer(obj[k].loc); }
-            }
-            obj = coverState.branchMap;
-            for (k in obj) {
-                /* istanbul ignore else: has own property */
-                if (obj.hasOwnProperty(k)) {
-                    locations = obj[k].locations;
-                    for (i = 0; i < locations.length; i += 1) {
-                        fixer(locations[i]);
-                    }
-                }
-            }
-        },
 
         fixLocation: function(loc, filename) {
             loc.start = this.babelSourceMap.originalPositionFor(loc.start);
@@ -693,9 +644,6 @@
                 branch.line = branch.locations[0].start.line;
             }, this);
 
-            if (!this.opts.noAutoWrap) {
-                this.fixColumnPositions(this.coverState);
-            }
             if (this.opts.embedSource) {
                 this.coverState.code = sourceCode.split(/(?:\r?\n)|\r/);
             }


### PR DESCRIPTION
Just for reference:

The original istanbul did this: https://github.com/gotwarlost/istanbul/blob/master/lib/instrumenter.js#L436-L438
That code is not present in babel-istanbul and all things depending on it can happily go.