### PR TITLE
correctly ignore functions that are not part of the source file

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -602,14 +602,14 @@
             return this.sourceMap;
         },
 
-        fixLocation: function(loc, filename) {
+        fixLocation: function(loc, filename, skip) {
             loc.start = this.babelSourceMap.originalPositionFor(loc.start);
             loc.end = this.babelSourceMap.originalPositionFor(loc.end);
 
             if (loc.start.source !== filename) {
                 loc.start = {line: 0, column: 0};
                 loc.end = {line: 0, column: 0};
-                loc.skip = true;
+                (skip || loc).skip = true;
             }
             delete loc.start.source;
             delete loc.start.name;
@@ -636,7 +636,7 @@
 
             Object.keys(this.coverState.fnMap).forEach(function(key) {
                 var fn = this.coverState.fnMap[key];
-                this.fixLocation(fn.loc, file);
+                this.fixLocation(fn.loc, file, fn);
                 fn.line = fn.loc.start.line;
             }, this);
 


### PR DESCRIPTION
babel generates getter functions for re-exports: http://babeljs.io/repl/#?code=export%20{foo%2C%20bar}%20from%20%22foobar%22

Those were not correctly ignored and lead to some missing coverage in my project and I had to investigate :-)