### PR TITLE
change the source map bias to LEAST_UPPER_BOUND

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -603,8 +603,10 @@
         },
 
         fixLocation: function(loc, filename, skip) {
-            loc.start = this.babelSourceMap.originalPositionFor(loc.start);
-            loc.end = this.babelSourceMap.originalPositionFor(loc.end);
+            var start = loc.start, end = loc.end;
+            start.bias = end.bias = SOURCE_MAP.SourceMapConsumer.LEAST_UPPER_BOUND;
+            loc.start = this.babelSourceMap.originalPositionFor(start);
+            loc.end = this.babelSourceMap.originalPositionFor(end);
 
             if (loc.start.source !== filename) {
                 loc.start = {line: 0, column: 0};


### PR DESCRIPTION
This fixes reporting of destructuring assignments for me.
Before their statements were ignored, because the 'start' loc had no match.
Now statement and line are correctly reported, although the column might be a bit off:
![bildschirmfoto vom 2015-06-22 03-12-30](https://cloud.githubusercontent.com/assets/580492/8274204/dd096758-188c-11e5-8cc8-8182e9080a79.png)
But its better than nothing