### PR TITLE
+ `babelConfig` as parameter

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -415,13 +415,15 @@
          *  the code was read. A temporary filename is generated when not specified.
          *  Not specifying a filename is only useful for unit tests and demonstrations
          *  of this library.
+         * @param {Object} babelConfig Optional. Advanced options for BABEL.
          */
-        instrumentSync: function (code, filename) {
-            var babelConfig = {
-                filename: filename,
-                sourceMap: true
-            }
+        instrumentSync: function (code, filename, babelConfig) {
             var program, transformed;
+
+            babelConfig = babelConfig || {};
+
+            babelConfig.filename = filename;
+            babelConfig.sourceMap = true;
 
             if (typeof code !== 'string') { throw new Error('Code must be string'); }
             if (code.charAt(0) === '#') { //shebang, 'comment' it out, won't affect syntax tree locations for things we care about


### PR DESCRIPTION
`babelConfig` — advanced options for BABEL, ex: `{modules: 'amd'}`