### PR TITLE
Windows coverage reported as 100% 

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -96,15 +96,6 @@ Collector.prototype = {
         var mod = {
           path: ret.path,
         };
-        doFilterMap('s', filterStatement);
-        doFilterMap('f', filterFunction);
-        doFilterMap('l', filterLine);
-        doFilterMap('b', filterBranch);
-        doFilterMap('statementMap', filterStatement);
-        doFilterMap('fnMap', filterFunction);
-        doFilterMap('branchMap', filterBranch);
-
-        return mod;
 
         function doFilterMap(key, filter) {
           var original = ret[key];
@@ -132,6 +123,16 @@ Collector.prototype = {
         function filterBranch(i) {
           return ret.branchMap[i].line > 0;
         }
+
+        doFilterMap('s', filterStatement);
+        doFilterMap('f', filterFunction);
+        doFilterMap('l', filterLine);
+        doFilterMap('b', filterBranch);
+        doFilterMap('statementMap', filterStatement);
+        doFilterMap('fnMap', filterFunction);
+        doFilterMap('branchMap', filterBranch);
+
+        return mod;
     },
     /**
      * returns file coverage information for all files. This has the same format as

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -623,7 +623,7 @@
 
         getPreamble: function (sourceCode, emitUseStrict) {
             var varName = this.opts.coverageVariable || '__coverage__',
-                file = this.coverState.path.replace(/\\/g, '\\\\'),
+                file = this.coverState.path.replace(/\\/g, '/'),
                 tracker = this.currentState.trackerVar,
                 coverState,
                 strictLine = emitUseStrict ? '"use strict";' : '',

--- a/lib/util/tree-summarizer.js
+++ b/lib/util/tree-summarizer.js
@@ -4,7 +4,7 @@
  */
 
 var path = require('path'),
-    SEP = path.sep || '/',
+    SEP = '/',
     utils = require('../object-utils');
 
 function commonArrayPrefix(first, second) {

--- a/test/instrumentation/test-statement.js
+++ b/test/instrumentation/test-statement.js
@@ -43,14 +43,14 @@ module.exports = {
                 'var x = args[0] > 5 ? args[0] : "undef";',
                 'output = x;'
             ];
-            verifier = helper.verifier("c:\\a\\b\\c\\d\\e.js", code);
+            verifier = helper.verifier("c:/a/b/c/d/e.js", code);
             cb();
         },
         "should have correct key in coverage variable": function (test) {
             verifier.verify(test, [ 1 ], "undef", { lines: { 1: 1, 2: 1 }, branches: { 1: [ 0, 1 ]}, functions: {}, statements: { 1: 1, 2: 1 } });
             var coverage = verifier.getCoverage(),
                 key = Object.keys(coverage)[0];
-            test.equals("c:\\a\\b\\c\\d\\e.js", key);
+            test.equals("c:/a/b/c/d/e.js", key);
             test.done();
         }
 


### PR DESCRIPTION
On Windows the file paths are not parsed correctly. Thus all coverage is reported as 100% for all files. This can be fixed by converting Windows path separator \ (previously converted to \\) into*nix separator /. 

The previous change breaks the summarizer, which does not group files under the same path anymore and shows full paths for all files. This can be fixed by making the converter use *nix separator / only.

This change does not break any additional tests. In my environments and Travis, some tests are broken regardless. If this is not intentional, I would appreciate an environment setup instructions in the documentation.