### PR TITLE
[added] a `--babel-config` CLI option - a configurable alternative to .babelrc

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -24,6 +24,7 @@ function usage(arg0, command) {
     console.error('\nUsage: ' + arg0 + ' ' + command + ' [<options>] <executable-js-file-or-command> [-- <arguments-to-jsfile>]\n\nOptions are:\n\n'
         + [
             formatOption('--config <path-to-config>', 'the configuration file to use, defaults to .istanbul.yml'),
+            formatOption('--babel-config <path-to-config>', 'a babel specific configuration file, same as .babelrc, supports YAML'),
             formatOption('--root <path> ', 'the root path to look for files to instrument, defaults to .'),
             formatOption('-x <exclude-pattern> [-x <exclude-pattern>]', 'one or more fileset patterns e.g. "**/vendor/**"'),
             formatOption('-i <include-pattern> [-i <include-pattern>]', 'one or more fileset patterns e.g. "**/*.js"'),
@@ -45,6 +46,7 @@ function run(args, commandName, enableHooks, callback) {
 
     var template = {
             config: path,
+            'babel-config': path,
             root: path,
             x: [ Array, String ],
             report: [Array, String ],
@@ -85,6 +87,7 @@ function run(args, commandName, enableHooks, callback) {
             }
         },
         config = configuration.loadFile(opts.config, overrides),
+        babelConfig = opts['babel-config'] ? configuration.readFile(opts['babel-config']) : {},
         verbose = config.verbose,
         cmdAndArgs = opts.argv.remain,
         preserveComments = opts['preserve-comments'],
@@ -157,6 +160,7 @@ function run(args, commandName, enableHooks, callback) {
 
                 var coverageVar = '$$cov_' + new Date().getTime() + '$$',
                     instrumenter = new Instrumenter({
+                        babelConfig: babelConfig,
                         coverageVariable: coverageVar,
                         preserveComments: preserveComments
                     }),

--- a/lib/config.js
+++ b/lib/config.js
@@ -412,6 +412,11 @@ function Configuration(obj, overrides) {
  * @type HookOptions
  */
 
+function readFile(file) {
+  return file.match(YML_PATTERN) ?
+    yaml.safeLoad(fs.readFileSync(file, 'utf8'), {filename: file}) :
+    require(path.resolve(file));
+}
 
 function loadFile(file, overrides) {
     var defaultConfigFile = path.resolve('.istanbul.yml'),
@@ -431,9 +436,7 @@ function loadFile(file, overrides) {
         if (overrides && overrides.verbose === true) {
             console.error('Loading config: ' + file);
         }
-        configObject = file.match(YML_PATTERN) ?
-            yaml.safeLoad(fs.readFileSync(file, 'utf8'), { filename: file }) :
-            require(path.resolve(file));
+        configObject = readFile(file);
     }
 
     return new Configuration(configObject, overrides);
@@ -470,6 +473,14 @@ module.exports = {
      * @return {Configuration} the config object with overrides applied
      */
     loadFile: loadFile,
+    /**
+     * reads the contents of a configuration file
+     * @method readFile
+     * @static
+     * @param {String} file the file to read
+     * @return {Object} configuration object
+     */
+    readFile: readFile,
     /**
      * loads the specified configuration object with optional overrides.
      * @method loadObject

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -13,6 +13,7 @@
         ESP = isNode ? require('esprima') : esprima,
         ESPGEN = isNode ? require('escodegen') : escodegen,  //TODO - package as dependency
         crypto = isNode ? require('crypto') : null,
+        objectAssign = isNode ? require('object-assign') : null,
         COMMENT_RE = /^\s*istanbul\s+ignore\s+(if|else|next)(?=\W|$)/,
         astgen,
         preconditions,
@@ -443,7 +444,7 @@
         instrumentSync: function (code, filename, babelConfig) {
             var program, transformed;
 
-            babelConfig = Object.assign({}, this.opts.babelConfig, babelConfig);
+            babelConfig = objectAssign({}, this.opts.babelConfig, babelConfig);
 
             babelConfig.filename = filename;
             babelConfig.sourceMaps = true;

--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -378,6 +378,7 @@
      */
     function Instrumenter(options) {
         this.opts = options || {
+            babelConfig: {},
             debug: false,
             walkDebug: false,
             coverageVariable: '__coverage__',
@@ -442,7 +443,7 @@
         instrumentSync: function (code, filename, babelConfig) {
             var program, transformed;
 
-            babelConfig = babelConfig || {};
+            babelConfig = Object.assign({}, this.opts.babelConfig, babelConfig);
 
             babelConfig.filename = filename;
             babelConfig.sourceMaps = true;

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "js-yaml": "3.x",
     "mkdirp": "0.5.x",
     "nopt": "3.x",
+    "object-assign": "^4.0.1",
     "once": "1.x",
     "resolve": "1.1.x",
     "source-map": "0.4.x",


### PR DESCRIPTION
The `--babel-config` CLI option lets you set a specific configuration file to use for babel.
It's an alternative to `.babelrc`, but it can be located anywhere, so one does not have to rely on Babel searching the file system for it.
Supports .yaml, .yml, .json and .js files.