### PR TITLE
[changed] catch babel transformation exceptions and pipe them to stderr

### DIFF
--- a/lib/command/common/run-with-cover.js
+++ b/lib/command/common/run-with-cover.js
@@ -224,7 +224,16 @@ function run(args, commandName, enableHooks, callback) {
                         // illustrate the missing coverage.
                         matchFn.files.forEach(function (file) {
                             if (!cov[file]) {
-                                transformer(fs.readFileSync(file, 'utf-8'), file);
+                                try {
+                                    transformer(fs.readFileSync(file, 'utf-8'), file);
+                                } catch (e) {
+                                    // print to stderr, because exceptions are not piped through in the exit handler,
+                                    // but instead cause the script to terminate prematurely without any indication of error
+                                    console.error(e.toString());
+                                    // there's not point in proceeding any further, if we did - the coverage report would
+                                    // be generated and most likely produce incorrect results, which could go unnoticed
+                                    process.exit(1);
+                                }
 
                                 // When instrumenting the code, istanbul will give each FunctionDeclaration a value of 1 in coverState.s,
                                 // presumably to compensate for function hoisting. We need to reset this, as the function was not hoisted,


### PR DESCRIPTION
When Babel transformation fails for some reason and an exception is thrown - an empty `coverage` directory is created and no report is printed to the terminal (because Babel is called in the process exit handler).
As a result Istanbul simply refuses to work without any indication of error.
Kind of like is described [here](https://github.com/gotwarlost/istanbul/issues/437).