### PR TITLE
Add suggestion to replace istanbul in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@
 
 * babel-istanbul is run exactly like istanbul. For specifics on running istanbul, see [istanbul's README](https://github.com/gotwarlost/istanbul/blob/master/README.md).
 
+### Optional configuration
+
+To effectively replace istanbul during the execution of your application, insert the following lines at the top of your file:
+
+```javascript
+require('babel-istanbul');
+require.cache[require.resolve('istanbul')] = require.cache[require.resolve('babel-istanbul')];
+```
+
+This may be needed if you use any 3rd party module that requires istanbul internally, like karma-coverage.
+
+Only do this if you have istanbul in your node_modules folder or `require.resolve('istanbul')` will throw an exception.
 
 ### Special flags
 


### PR DESCRIPTION
Added a suggestion to insert babel-istanbul module into require.cache as istanbul, so every module that requires istanbul gets babel-istanbul instead.

This solved a problem that occurred to me using karma-coverage, it was collecting the stats from babel compiled file, not from the source.

Before:
82.5% Statements 33/40
100% Branches 17/17
66.67% Functions 4/6
73.68% Lines 14/19
3 branches Ignored

After:
75% Statements 21/28
100% Branches 8/8
60% Functions 3/5
72.22% Lines 13/18

This could be a method, so you can call `require('babel-istanbul').replaceIstanbul()`.